### PR TITLE
Enhance client-side recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# recommendation_engine
-Recommendation Engine
+# Recommendation Engine
+
+This repository contains a very small demo website that shows how a simple
+video recommendation system can work completely in the browser.  Users can be
+selected from the landing page, then a video can be chosen.  Ten seconds into
+playback the page will suggest another video based on the selected user's
+preferences and prior watch history (stored in the browser's `localStorage`).
+
+## Running locally
+
+Open `site/index.html` in a web browser.  Because everything is client-side no
+server is required.  The provided sample videos are pulled from
+`sample-videos.com`, so an internet connection is needed for playback.
+
+You can replace the entries in `site/js/app.js` with your own video URLs and
+tags.  When new videos are added simply update the `videos` array.
+
+## Updating your Codespace
+
+If you wish to modify this project in a Codespace, clone the repository and
+apply your changes.  Commit them with `git commit` and then push with
+`git push`.

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Welcome</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Select User</h1>
+    <ul>
+        <li><a href="video_select.html?user=Alice">Alice</a></li>
+        <li><a href="video_select.html?user=Bob">Bob</a></li>
+        <li><a href="video_select.html?user=Charlie">Charlie</a></li>
+    </ul>
+</body>
+</html>

--- a/site/js/app.js
+++ b/site/js/app.js
@@ -1,0 +1,101 @@
+const users = {
+    Alice: {likes: ['adventure', 'sci-fi'], history: []},
+    Bob: {likes: ['comedy', 'drama'], history: []},
+    Charlie: {likes: ['documentary'], history: []}
+};
+
+function loadUserHistory(userId) {
+    const raw = localStorage.getItem(`history_${userId}`);
+    if (raw) {
+        try {
+            users[userId].history = JSON.parse(raw);
+        } catch {
+            users[userId].history = [];
+        }
+    }
+}
+
+function saveUserHistory(userId) {
+    localStorage.setItem(`history_${userId}`,
+        JSON.stringify(users[userId].history));
+}
+
+const videos = [
+    {id: 'vid1', title: 'Adventure in Space', url: 'https://sample-videos.com/video123/mp4/720/big_buck_bunny_720p_1mb.mp4', tags: ['adventure', 'sci-fi']},
+    {id: 'vid2', title: 'Funny Times', url: 'https://sample-videos.com/video123/mp4/720/big_buck_bunny_720p_1mb.mp4', tags: ['comedy']},
+    {id: 'vid3', title: 'Nature Documentary', url: 'https://sample-videos.com/video123/mp4/720/big_buck_bunny_720p_1mb.mp4', tags: ['documentary']}
+];
+
+function getQueryParam(name) {
+    const params = new URLSearchParams(window.location.search);
+    return params.get(name);
+}
+
+function buildVideoList() {
+    const user = getQueryParam('user');
+    loadUserHistory(user);
+    const container = document.getElementById('video-list');
+    videos.forEach(v => {
+        const link = document.createElement('a');
+        link.href = `watch.html?user=${user}&video=${v.id}`;
+        link.textContent = v.title;
+        const div = document.createElement('div');
+        div.appendChild(link);
+        container.appendChild(div);
+    });
+}
+
+function loadVideo() {
+    const videoId = getQueryParam('video');
+    const userId = getQueryParam('user');
+    loadUserHistory(userId);
+    const video = videos.find(v => v.id === videoId);
+    if (!video) return;
+    const player = document.getElementById('player');
+    player.src = video.url;
+    document.getElementById('video-title').textContent = video.title;
+
+    const recommendation = document.getElementById('recommendation');
+    let recommendationShown = false;
+    player.addEventListener('timeupdate', () => {
+        if (player.currentTime > 10 && !recommendationShown) {
+            recommendationShown = true;
+            if (!users[userId].history.includes(video.id)) {
+                users[userId].history.push(video.id);
+                saveUserHistory(userId);
+            }
+            const rec = recommend(video, users[userId]);
+            recommendation.innerHTML = `<strong>Recommended for you:</strong> ${rec.title}`;
+            recommendation.classList.remove('hidden');
+        }
+    });
+}
+
+function recommend(currentVideo, user) {
+    const historyTags = user.history
+        .map(id => videos.find(v => v.id === id))
+        .filter(Boolean)
+        .flatMap(v => v.tags);
+
+    let best = null;
+    let bestScore = -1;
+    videos.forEach(v => {
+        if (v.id === currentVideo.id) return;
+        let score = 0;
+        v.tags.forEach(t => {
+            if (user.likes.includes(t)) score += 2;
+            if (historyTags.includes(t)) score += 1;
+        });
+        if (score > bestScore) {
+            bestScore = score;
+            best = v;
+        }
+    });
+    return best || videos.find(v => v.id !== currentVideo.id);
+}
+
+if (document.getElementById('video-list')) {
+    buildVideoList();
+} else if (document.getElementById('player')) {
+    loadVideo();
+}

--- a/site/style.css
+++ b/site/style.css
@@ -1,0 +1,15 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+.hidden { display: none; }
+#recommendation {
+    background: #f0f0f0;
+    padding: 10px;
+    margin-top: 15px;
+}
+.popup {
+    border: 1px solid #ccc;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: calc(100% - 2em);
+    margin: 1em;
+}

--- a/site/video_select.html
+++ b/site/video_select.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Select Video</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Select Video</h1>
+    <div id="video-list"></div>
+    <script src="js/app.js"></script>
+</body>
+</html>

--- a/site/watch.html
+++ b/site/watch.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Watch Video</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1 id="video-title"></h1>
+    <video id="player" width="640" controls></video>
+    <div id="recommendation" class="popup hidden"></div>
+    <script src="js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- improve README with usage instructions
- add persistent user history via `localStorage`
- compute recommendations based on past views
- display popup recommendation overlay while watching

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bcec054fc8328a4156c6c5c9bfed9